### PR TITLE
add md5 checkums dumping

### DIFF
--- a/gogverify.py
+++ b/gogverify.py
@@ -145,7 +145,7 @@ def main():
     if args.dump_md5sums:
         for file in files:
             if not file.is_dir:
-            log(f"{file.md5}  {file.path}")
+                log(f"{file.md5}  {file.path}")
         exit(0)
 
     file_paths = {file.path for file in files}


### PR DESCRIPTION
A new argument that allows dumping all md5 checksums for a given buildID and game.

This is actually what led me to your awesome tool here. Just earlier today I was looking to cobble something together that took a gog build id and spat out a nice simple, and much more compatible, md5sum file. I was extremely delighted to find that someone had already done all of the heavy lifting for me :smile:. This minimal tweak achieves what I wanted to do perfectly.

Thank you very much for releasing this extremely handy tool!